### PR TITLE
Skip tests that take too long.

### DIFF
--- a/TFCTestObject.py
+++ b/TFCTestObject.py
@@ -51,8 +51,8 @@ class TFCTestObject(TFCObject):
                                 "via mpi.")
         params.addOptionalParam("num_procs", 1,
                                 "The number of mpi processes used.")
-        params.addOptionalParam("weight_class", "short",
-                                "The weight class short/intermediate/long")
+        params.addOptionalParam("weight_class", "",
+                                "The weight class")
         params.addOptionalParam("outfileprefix", "",
                                 'Will default to the test name + .out, '
                                 'otherwise outfileprefix+.out.')
@@ -183,10 +183,10 @@ class TFCTestObject(TFCObject):
                 if test_true_name == dep_name:
                     if not test.ran_:
                         return False
-                    # Check if the dependency was skipped
-                    if test.skip_ != "":
+                    # Check if the dependency failed
+                    if test.fail_flag_ != "":
                         if self.skip_ == "":
-                            self.skip_ = "Parent was skipped."
+                            self.skip_ = "Parent failed."
 
         return True
 
@@ -250,6 +250,45 @@ class TFCTestObject(TFCObject):
                                         universal_newlines=True)
 
 
+    def messageResult(self, max_num_procs, print_width, annotations, cntl_char_pad) -> tuple:
+        pcount_width = int(math.floor(math.log10(max_num_procs)))+1
+
+        prefix = f"\033[33m[{self.num_procs_:{pcount_width}d}]\033[0m  "
+        cntl_char_pad += 5 + 4
+
+        suffix = ""
+        for annotation in annotations:
+            if self.fail_flag_ != "":
+                suffix += "  \033[35m[" + annotation + "]\033[0m"
+            else:
+                suffix += "  \033[36m[" + annotation + "]\033[0m"
+            cntl_char_pad += 5 + 4
+        suffix += "  \033[32mPassed\033[0m" if self.passed_ else (
+            "  \033[35mFailed\033[0m" if self.fail_flag_ != "" else
+            "  \033[31mFailed\033[0m")
+
+        self.test_result_annotation_ = ""
+        for annotation in annotations:
+            self.test_result_annotation_ += f"[{annotation}]"
+
+        cntl_char_pad += 5 + 4
+
+        # pretty_name = os.path.relpath(self.name_, PROJECT_ROOT_PATH)
+        pretty_name = self.name_ # experimental
+
+        time_taken = self._time_end_ - self._time_start_
+
+        width = print_width - len(prefix) - len(pretty_name) \
+              - len(suffix) + cntl_char_pad
+        width = max(width, 0)
+
+        suffix = '  ' + '.' * width + suffix + f" {time_taken:.1g}s"
+
+        message = prefix + pretty_name + suffix
+
+        return message, cntl_char_pad
+
+
     def checkProgress(self, test_system) -> str:
         """Checks whether the process is running and returns 'Running' if it is.
         If it is not running anymore the checks will be executed."""
@@ -264,20 +303,6 @@ class TFCTestObject(TFCObject):
         cntl_char_pad = 0
 
         self.fail_flag_reason_ = ""
-
-        # Check if the test has run beyond permitted time.
-        # This prevents hanging tests that never finish.
-        if self.weight_class_ == "short":
-            if self._time_current_ >= 300.0: # 5 minutes
-                self.skip_ = "Short test ran longer than 5 minutes."
-        elif self.weight_class_ == "medium":
-            if self._time_current_ >= 600.0: # 10 minutes
-                self.skip_ = "Medium test ran longer than 10 minutes."
-        elif self.weight_class_ == "long":
-            if self._time_current_ >= 1800.0: # 30 minutes
-                self.skip_ = "Long test ran longer than 30 minutes."
-        else:
-            pass
 
         if self.skip_ == "":
 
@@ -297,10 +322,33 @@ class TFCTestObject(TFCObject):
                 file.write(out + "\n")
                 file.write(err + "\n")
                 file.close()
-                # self.ran_ = True
+
             else:
                 # Set the current run time so we can check if the test is hanging
                 self._time_current_ = time.perf_counter() - self._time_start_
+
+                # Check if the test has run beyond permitted time.
+                # This prevents hanging tests that never finish.
+                for weight_name in test_system.weight_map_:
+                    for weight, time_limit in weight_name.items():
+                        if self.weight_class_ == weight:
+                            if self._time_current_ >= time_limit:
+                                self.fail_flag_ = (
+                                f'Weight "{self.weight_class_}" test time of '
+                                f'{self._time_current_:.1f}s >= time limit of {time_limit}s.')
+                                annotations.append(f"Note: {self.fail_flag_}")
+                                self.fail_flag_reason_ = f"Fail flag: {self.fail_flag_}"
+                                self._process_.terminate()
+                                self._time_end_ = time.perf_counter()
+                                message, cntl_char_pad = (
+                                self.messageResult(test_system.max_num_procs_,
+                                                   test_system.print_width_,
+                                                   annotations,
+                                                   cntl_char_pad))
+                                print(message)
+                                self.ran_ = True
+                                return "Done"
+
                 return "Running"
 
             if not self.precheck_script_ == "":
@@ -355,53 +403,15 @@ class TFCTestObject(TFCObject):
                 pass
 
         else: # skipped
-            if self._process_:
-               self._process_.terminate()
             self._time_end_ = time.perf_counter()
             self.passed_ = True
-            # self.ran_ = True
             annotations.append( f"Skipped: {self.skip_}" )
 
-        max_num_procs = test_system.max_num_procs_
-        pcount_width = int(math.floor(math.log10(max_num_procs)))+1
-
-        prefix = f"\033[33m[{self.num_procs_:{pcount_width}d}]\033[0m  "
-        cntl_char_pad += 5 + 4
-
-        suffix = ""
-        for annotation in annotations:
-            if self.fail_flag_ != "":
-                suffix += "  \033[35m[" + annotation + "]\033[0m"
-            else:
-                suffix += "  \033[36m[" + annotation + "]\033[0m"
-            cntl_char_pad += 5 + 4
-        suffix += "  \033[32mPassed\033[0m" if self.passed_ else (
-            "  \033[35mFailed\033[0m" if self.fail_flag_ != "" else
-            "  \033[31mFailed\033[0m")
-
-        self.test_result_annotation_ = ""
-        for annotation in annotations:
-            self.test_result_annotation_ += f"[{annotation}]"
-
-
-        cntl_char_pad += 5 + 4
-
-        # pretty_name = os.path.relpath(self.name_, PROJECT_ROOT_PATH)
-        pretty_name = self.name_ # experimental
-
-        time_taken = self._time_end_ - self._time_start_
-
-        width = test_system.print_width_ - len(prefix) - len(pretty_name) \
-              - len(suffix) + cntl_char_pad
-        width = max(width, 0)
-
-        suffix = '  ' + '.' * width + suffix + f" {time_taken:.1g}s"
-
-        message = prefix + pretty_name + suffix
-
+        message, cntl_char_pad = self.messageResult(test_system.max_num_procs_,
+                                                    test_system.print_width_,
+                                                    annotations,
+                                                    cntl_char_pad)
         print(message)
-
-        # if not os.path.exists():
 
         if self.skip_ == "":
             if not self.postrun_script_ == "":

--- a/TFCTestObject.py
+++ b/TFCTestObject.py
@@ -141,6 +141,7 @@ class TFCTestObject(TFCObject):
         self.ran_: bool = False
         self.submitted_: bool = False
         self.passed_: bool = False
+        self.parent_failed_: bool = False
 
         self.test_result_annotation_ = ""
 
@@ -184,10 +185,8 @@ class TFCTestObject(TFCObject):
                     if not test.ran_:
                         return False
                     # Check if the dependency failed
-                    if test.fail_flag_ != "":
-                        if self.skip_ == "":
-                            self.skip_ = "Parent failed."
-
+                    if test.passed_ == False:
+                        self.parent_failed_ = True
         return True
 
     def submit(self, test_system) -> None:
@@ -196,7 +195,7 @@ class TFCTestObject(TFCObject):
 
         dir_, filename_ = os.path.split(self.name_)
 
-        if self.skip_ != "":
+        if self.skip_ != "" or self.parent_failed_ == True:
 
             return
 
@@ -258,13 +257,13 @@ class TFCTestObject(TFCObject):
 
         suffix = ""
         for annotation in annotations:
-            if self.fail_flag_ != "":
+            if self.fail_flag_ != "" or self.parent_failed_:
                 suffix += "  \033[35m[" + annotation + "]\033[0m"
             else:
                 suffix += "  \033[36m[" + annotation + "]\033[0m"
             cntl_char_pad += 5 + 4
         suffix += "  \033[32mPassed\033[0m" if self.passed_ else (
-            "  \033[35mFailed\033[0m" if self.fail_flag_ != "" else
+            "  \033[35mFailed\033[0m" if self.fail_flag_ != "" or self.parent_failed_ else
             "  \033[31mFailed\033[0m")
 
         self.test_result_annotation_ = ""
@@ -306,6 +305,19 @@ class TFCTestObject(TFCObject):
 
         if self.skip_ == "":
 
+            if self.parent_failed_ == True:
+                self.fail_flag_reason_ = "Parent failed."
+                annotations.append(f"Note: {self.fail_flag_reason_}")
+                # self._process_.terminate()
+                message, cntl_char_pad = (
+                self.messageResult(test_system.max_num_procs_,
+                                   test_system.print_width_,
+                                   annotations,
+                                   cntl_char_pad))
+                print(message)
+                self.ran_ = True
+                return "Done"
+
             if self._process_.poll() is not None:
 
                 out, err = self._process_.communicate()
@@ -324,6 +336,7 @@ class TFCTestObject(TFCObject):
                 file.close()
 
             else:
+
                 # Set the current run time so we can check if the test is hanging
                 self._time_current_ = time.perf_counter() - self._time_start_
 

--- a/TFCTestObject.py
+++ b/TFCTestObject.py
@@ -52,7 +52,16 @@ class TFCTestObject(TFCObject):
         params.addOptionalParam("num_procs", 1,
                                 "The number of mpi processes used.")
         params.addOptionalParam("weight_class", "",
-                                "The weight class")
+                                "The weight class of this test. The classes "
+                                "allowed depends on whether a custom weight "
+                                "map has been assigned in the test system's "
+                                "config file. If no custom weight map is "
+                                "assigned then the weight class will be short, "
+                                "intermediate, or long, otherwise the weight "
+                                "class must correspond to one of the classes "
+                                "in the custom map. If not supplied the test "
+                                "will revert to what the test system's "
+                                "default is.")
         params.addOptionalParam("outfileprefix", "",
                                 'Will default to the test name + .out, '
                                 'otherwise outfileprefix+.out.')
@@ -263,7 +272,36 @@ class TFCTestObject(TFCObject):
                                         universal_newlines=True)
 
 
-    def messageResult(self, max_num_procs, print_width, annotations, cntl_char_pad) -> tuple:
+    def messageResult(self, max_num_procs: int, print_width: int,
+                      annotations: list[str], cntl_char_pad: int) -> tuple:
+        """
+        Generates a formatted message summarizing the result of a test or
+        process execution, along with updated control character padding.
+
+        Args:
+            max_num_procs (int):       The maximum number of processes used,
+                                       which determines the width of the process
+                                       count in the output string.
+
+            print_width (int):         The desired width of the output string,
+                                       used for formatting.
+
+            annotations (list of str): A list of annotations to include in the
+                                       result message.
+
+            cntl_char_pad (int):       The initial padding for control
+                                       characters, which will be updated
+                                       based on the formatting applied in
+                                       the message.
+        Returns:
+            tuple: A tuple containing:
+                - message (str):       The formatted result message including
+                                       process count, test name, annotations,
+                                       pass/fail status, and execution time.
+
+                - cntl_char_pad (int): The updated control character padding
+                                       after formatting.
+        """
         pcount_width = int(math.floor(math.log10(max_num_procs)))+1
 
         prefix = f"\033[33m[{self.num_procs_:{pcount_width}d}]\033[0m  "
@@ -350,33 +388,33 @@ class TFCTestObject(TFCObject):
 
             else:
 
-                # Set the current run time so we can check if the test is hanging
-                self._time_current_ = time.perf_counter() - self._time_start_
-
                 # If time limits are being enforced
                 if not test_system.no_time_limit_:
+
+                    # Set the current run time so we can check if the test is hanging
+                    self._time_current_ = time.perf_counter() - self._time_start_
+
                     # Check if the test has run beyond permitted time.
                     # This prevents hanging tests that never finish.
-                    for weight_name in test_system.weight_map_:
-                        for weight, time_limit in weight_name.items():
-                            if self.weight_class_ == weight:
-                                if self._time_current_ >= time_limit:
-                                    self.time_limit_ = True
-                                    self.fail_flag_ = (
-                                    f'"{self.weight_class_}" weight test '
-                                    f'exceeded time limit of {time_limit}s.')
-                                    annotations.append(f"Note: {self.fail_flag_}")
-                                    self.fail_flag_reason_ = f"Fail flag: {self.fail_flag_}"
-                                    self._process_.terminate()
-                                    self._time_end_ = time.perf_counter()
-                                    message, cntl_char_pad = (
-                                    self.messageResult(test_system.max_num_procs_,
-                                                       test_system.print_width_,
-                                                       annotations,
-                                                       cntl_char_pad))
-                                    print(message)
-                                    self.ran_ = True
-                                    return "Done"
+                    if self.weight_class_ in test_system.weight_map_:
+                        time_limit = test_system.weight_map_[self.weight_class_]
+                        if self._time_current_ >= time_limit:
+                            self.time_limit_ = True
+                            self.fail_flag_ = (
+                            f'"{self.weight_class_}" weight test '
+                            f'exceeded time limit of {time_limit}s.')
+                            annotations.append(f"Note: {self.fail_flag_}")
+                            self.fail_flag_reason_ = f"Fail flag: {self.fail_flag_}"
+                            self._process_.terminate()
+                            self._time_end_ = time.perf_counter()
+                            message, cntl_char_pad = (
+                            self.messageResult(test_system.max_num_procs_,
+                                               test_system.print_width_,
+                                               annotations,
+                                               cntl_char_pad))
+                            print(message)
+                            self.ran_ = True
+                            return "Done"
 
                 return "Running"
 

--- a/TFCTestObject.py
+++ b/TFCTestObject.py
@@ -124,6 +124,7 @@ class TFCTestObject(TFCObject):
         self._process_ = None
         self._time_start_ = time.perf_counter()
         self._time_end_ = time.perf_counter()
+        self._time_current_ = 0.0
         self._command_ = ""
 
         self.check_inputs = params.getParam("checks")
@@ -179,8 +180,14 @@ class TFCTestObject(TFCObject):
                 last_dash = test_name.rfind("/")
                 test_true_name = test_name if last_dash < 0 else test_name[last_dash+1:]
 
-                if test_true_name == dep_name and not test.ran_:
-                    return False
+                if test_true_name == dep_name:
+                    if not test.ran_:
+                        return False
+                    # Check if the dependency was skipped
+                    if test.skip_ != "":
+                        if self.skip_ == "":
+                            self.skip_ = "Parent was skipped."
+
         return True
 
     def submit(self, test_system) -> None:
@@ -278,6 +285,8 @@ class TFCTestObject(TFCObject):
                 file.close()
                 # self.ran_ = True
             else:
+                # Set the current run time so we can check if the test is hanging
+                self._time_current_ = time.perf_counter() - self._time_start_
                 return "Running"
 
             if not self.precheck_script_ == "":

--- a/TFCTestObject.py
+++ b/TFCTestObject.py
@@ -142,6 +142,7 @@ class TFCTestObject(TFCObject):
         self.submitted_: bool = False
         self.passed_: bool = False
         self.parent_failed_: bool = False
+        self.time_limit_: bool = False
 
         self.test_result_annotation_ = ""
 
@@ -185,8 +186,10 @@ class TFCTestObject(TFCObject):
                     if not test.ran_:
                         return False
                     # Check if the dependency failed
-                    if test.passed_ == False:
+                    if test.time_limit_ == True:
                         self.parent_failed_ = True
+                        self.fail_flag_ = test.name_.rsplit("/", 1)[-1]
+
         return True
 
     def submit(self, test_system) -> None:
@@ -306,9 +309,8 @@ class TFCTestObject(TFCObject):
         if self.skip_ == "":
 
             if self.parent_failed_ == True:
-                self.fail_flag_reason_ = "Parent failed."
+                self.fail_flag_reason_ = f'Parent "{self.fail_flag_}" failed.'
                 annotations.append(f"Note: {self.fail_flag_reason_}")
-                # self._process_.terminate()
                 message, cntl_char_pad = (
                 self.messageResult(test_system.max_num_procs_,
                                    test_system.print_width_,
@@ -346,6 +348,7 @@ class TFCTestObject(TFCObject):
                     for weight, time_limit in weight_name.items():
                         if self.weight_class_ == weight:
                             if self._time_current_ >= time_limit:
+                                self.time_limit_ = True
                                 self.fail_flag_ = (
                                 f'Weight "{self.weight_class_}" test time of '
                                 f'{self._time_current_:.1f}s >= time limit of {time_limit}s.')

--- a/TFCTestObject.py
+++ b/TFCTestObject.py
@@ -265,6 +265,20 @@ class TFCTestObject(TFCObject):
 
         self.fail_flag_reason_ = ""
 
+        # Check if the test has run beyond permitted time.
+        # This prevents hanging tests that never finish.
+        if self.weight_class_ == "short":
+            if self._time_current_ >= 300.0: # 5 minutes
+                self.skip_ = "Short test ran longer than 5 minutes."
+        elif self.weight_class_ == "medium":
+            if self._time_current_ >= 600.0: # 10 minutes
+                self.skip_ = "Medium test ran longer than 10 minutes."
+        elif self.weight_class_ == "long":
+            if self._time_current_ >= 1800.0: # 30 minutes
+                self.skip_ = "Long test ran longer than 30 minutes."
+        else:
+            pass
+
         if self.skip_ == "":
 
             if self._process_.poll() is not None:
@@ -341,6 +355,8 @@ class TFCTestObject(TFCObject):
                 pass
 
         else: # skipped
+            if self._process_:
+               self._process_.terminate()
             self._time_end_ = time.perf_counter()
             self.passed_ = True
             # self.ran_ = True

--- a/TFCTestObject.py
+++ b/TFCTestObject.py
@@ -141,7 +141,7 @@ class TFCTestObject(TFCObject):
         self.ran_: bool = False
         self.submitted_: bool = False
         self.passed_: bool = False
-        self.parent_failed_: bool = False
+        self.dependency_failed_: bool = False
         self.time_limit_: bool = False
 
         self.test_result_annotation_ = ""
@@ -175,20 +175,31 @@ class TFCTestObject(TFCObject):
         """Determines, from the supplied tests-list, whether this
         test's dependendent tests have run.
         """
+        try:
+           if str(*self.dependencies_.sub_params) == '""':
+               return True
+        except:
+           pass
+
         for dependency in self.dependencies_:
             dep_name = dependency.getStringValue()
+            dep_found = False
             for test in tests:
                 test_name = test.name_
                 last_dash = test_name.rfind("/")
                 test_true_name = test_name if last_dash < 0 else test_name[last_dash+1:]
 
                 if test_true_name == dep_name:
+                    dep_found = True
                     if not test.ran_:
                         return False
                     # Check if the dependency failed
                     if test.time_limit_ == True:
-                        self.parent_failed_ = True
+                        self.dependency_failed_ = True
                         self.fail_flag_ = test.name_.rsplit("/", 1)[-1]
+
+            if dep_found == False: # this test's depencency is not an active test
+                self.skip_ = "Dependency not active."
 
         return True
 
@@ -198,7 +209,7 @@ class TFCTestObject(TFCObject):
 
         dir_, filename_ = os.path.split(self.name_)
 
-        if self.skip_ != "" or self.parent_failed_ == True:
+        if self.skip_ != "" or self.dependency_failed_ == True:
 
             return
 
@@ -260,13 +271,13 @@ class TFCTestObject(TFCObject):
 
         suffix = ""
         for annotation in annotations:
-            if self.fail_flag_ != "" or self.parent_failed_:
+            if self.fail_flag_ != "" or self.dependency_failed_:
                 suffix += "  \033[35m[" + annotation + "]\033[0m"
             else:
                 suffix += "  \033[36m[" + annotation + "]\033[0m"
             cntl_char_pad += 5 + 4
         suffix += "  \033[32mPassed\033[0m" if self.passed_ else (
-            "  \033[35mFailed\033[0m" if self.fail_flag_ != "" or self.parent_failed_ else
+            "  \033[35mFailed\033[0m" if self.fail_flag_ != "" or self.dependency_failed_ else
             "  \033[31mFailed\033[0m")
 
         self.test_result_annotation_ = ""
@@ -308,8 +319,8 @@ class TFCTestObject(TFCObject):
 
         if self.skip_ == "":
 
-            if self.parent_failed_ == True:
-                self.fail_flag_reason_ = f'Parent "{self.fail_flag_}" failed.'
+            if self.dependency_failed_ == True:
+                self.fail_flag_reason_ = f'Dependency "{self.fail_flag_}" failed.'
                 annotations.append(f"Note: {self.fail_flag_reason_}")
                 message, cntl_char_pad = (
                 self.messageResult(test_system.max_num_procs_,

--- a/TFCTestObject.py
+++ b/TFCTestObject.py
@@ -342,28 +342,30 @@ class TFCTestObject(TFCObject):
                 # Set the current run time so we can check if the test is hanging
                 self._time_current_ = time.perf_counter() - self._time_start_
 
-                # Check if the test has run beyond permitted time.
-                # This prevents hanging tests that never finish.
-                for weight_name in test_system.weight_map_:
-                    for weight, time_limit in weight_name.items():
-                        if self.weight_class_ == weight:
-                            if self._time_current_ >= time_limit:
-                                self.time_limit_ = True
-                                self.fail_flag_ = (
-                                f'Weight "{self.weight_class_}" test time of '
-                                f'{self._time_current_:.1f}s >= time limit of {time_limit}s.')
-                                annotations.append(f"Note: {self.fail_flag_}")
-                                self.fail_flag_reason_ = f"Fail flag: {self.fail_flag_}"
-                                self._process_.terminate()
-                                self._time_end_ = time.perf_counter()
-                                message, cntl_char_pad = (
-                                self.messageResult(test_system.max_num_procs_,
-                                                   test_system.print_width_,
-                                                   annotations,
-                                                   cntl_char_pad))
-                                print(message)
-                                self.ran_ = True
-                                return "Done"
+                # If time limits are being enforced
+                if not test_system.no_time_limit_:
+                    # Check if the test has run beyond permitted time.
+                    # This prevents hanging tests that never finish.
+                    for weight_name in test_system.weight_map_:
+                        for weight, time_limit in weight_name.items():
+                            if self.weight_class_ == weight:
+                                if self._time_current_ >= time_limit:
+                                    self.time_limit_ = True
+                                    self.fail_flag_ = (
+                                    f'"{self.weight_class_}" weight test '
+                                    f'exceeded time limit of {time_limit}s.')
+                                    annotations.append(f"Note: {self.fail_flag_}")
+                                    self.fail_flag_reason_ = f"Fail flag: {self.fail_flag_}"
+                                    self._process_.terminate()
+                                    self._time_end_ = time.perf_counter()
+                                    message, cntl_char_pad = (
+                                    self.messageResult(test_system.max_num_procs_,
+                                                       test_system.print_width_,
+                                                       annotations,
+                                                       cntl_char_pad))
+                                    print(message)
+                                    self.ran_ = True
+                                    return "Done"
 
                 return "Running"
 

--- a/TFCTestSystem.py
+++ b/TFCTestSystem.py
@@ -81,6 +81,11 @@ class TFCTestSystem(TFCObject, TFCTraceabilityMatrix, TFCTestResultsDatabase):
                                 "traceability matrix.")
         params.addOptionalParam("test_results_database_outputfile", "TestResults.yaml",
                                 "File to which the results database is to be written.")
+        params.addOptionalParam("generate_requirements_matrix", False,
+                                "Generate requirements traceability matrix.")
+        params.addOptionalParam("generate_results_database", False,
+                                "Generate results database.")
+
 
         return params
 
@@ -117,6 +122,8 @@ class TFCTestSystem(TFCObject, TFCTraceabilityMatrix, TFCTestResultsDatabase):
             self.exclude_folders_.append(subparam.getStringValue())
 
         # Requirement Documents
+        self.generate_requirements_matrix_ = params.getParam("generate_requirements_matrix").getBooleanValue()
+
         requirement_docs = params.getParam("requirement_docs")
         self.requirement_docs_ = []
         for subparam in requirement_docs:
@@ -148,6 +155,7 @@ class TFCTestSystem(TFCObject, TFCTraceabilityMatrix, TFCTestResultsDatabase):
         self.requirements_matrix_outputfile_ = \
             params.getParam("requirements_matrix_outputfile").getStringValue()
 
+        self.generate_results_database_ = params.getParam("generate_results_database").getBooleanValue()
         self.test_results_database_outputfile_ = \
             params.getParam("test_results_database_outputfile").getStringValue()
 
@@ -554,8 +562,10 @@ class TFCTestSystem(TFCObject, TFCTraceabilityMatrix, TFCTestResultsDatabase):
         else:
             print(f"\033[31mNumber of failed tests            : {num_tests_failed}\033[0m")
 
-        self.writeRequirementsTraceabilityMatrix()
-        self.writeResultsDatabase()
+        if self.generate_requirements_matrix_:
+            self.writeRequirementsTraceabilityMatrix()
+        if self.generate_results_database_:
+            self.writeResultsDatabase()
 
         # Printing failure logs
         failure_reasons: list[str] = []

--- a/TFCTestSystem.py
+++ b/TFCTestSystem.py
@@ -161,7 +161,7 @@ class TFCTestSystem(TFCObject, TFCTraceabilityMatrix, TFCTestResultsDatabase):
         self.print_width_ = 120
         self.default_args_ = ""
         self.env_vars_ = []
-        self.default_weight_ = "short"
+        self.default_weight_ = ""
         self.weight_map_ = ""
 
         with open(config_file_path) as yaml_file:
@@ -183,8 +183,8 @@ class TFCTestSystem(TFCObject, TFCTraceabilityMatrix, TFCTestResultsDatabase):
 
         if self.weight_map_ == "":
             self.weight_map_ = [{"short": 2.0}, {"intermediate": 10.0}, {"long": 20.0}]
-            self.default_weight_ = "short"
-        else:
+
+        if self.default_weight_ != "":
             found_weight = False
             for weight_name in self.weight_map_:
                 for weight in weight_name.keys():
@@ -193,11 +193,19 @@ class TFCTestSystem(TFCObject, TFCTraceabilityMatrix, TFCTestResultsDatabase):
                         break
             if found_weight == False:
                 print(f'\033[31mWARNING: default_weight set in config file {self.config_file_} ' +
-                      f'but not found in default weight_map. Falling back to default_weight = "short"\033[0m')
-                self.weight_map_ = [{"short": 2.0}, {"intermediate": 10.0}, {"long": 20.0}]
-                self.default_weight_ = "short"
+                      f'but not found in weight_map. Ignoring default_weight.\033[0m')
+                self.default_weight_ = ""
+
+        if "all" in self.weights_:
+            self.weights_ = [weight for weight_map in self.weight_map_ for weight in weight_map.keys()]
 
         self.weight_classes_allowed_ = self.weights_
+
+        # Append "None" weight class to weight_classes_allowed
+        # This makes the test system agnostic to the weight class definitions
+        # and allows tests to run that have no assignment without explicity
+        # assigning them to an arbitrary member of the weight classes
+        self.weight_classes_allowed_.append(None)
 
         self.max_num_procs_ = 1
 
@@ -236,7 +244,8 @@ class TFCTestSystem(TFCObject, TFCTraceabilityMatrix, TFCTestResultsDatabase):
         print(f" Main executable        : {exe_printed_value}")
         print(f" Number of jobs         : {self.num_jobs_}")
         print(f" Weight classes         : {self.weight_classes_allowed_}")
-        print(f" Default weight class   : {self.default_weight_}")
+        if self.default_weight_ != "":
+            print(f" Default weight class   : {self.default_weight_}")
         print(f" Compiler env-var       : {self.compiler_}")
         print(f" System details         : {self.os_details_}")
         print(f" System version         : {self.os_version_}")
@@ -345,8 +354,6 @@ class TFCTestSystem(TFCObject, TFCTraceabilityMatrix, TFCTestResultsDatabase):
 
                     # check if weight class is allowed
                     if 'weight_class' not in temp_dict:
-                        temp_dict['weight_class'] = self.default_weight_
-                        if self.default_weight_ not in self.weight_classes_allowed_:
                             continue
                     else:
                         if temp_dict['weight_class'] not in self.weight_classes_allowed_:
@@ -367,6 +374,12 @@ class TFCTestSystem(TFCObject, TFCTraceabilityMatrix, TFCTestResultsDatabase):
             # make tests
             for test_name in new_yaml_dict:
                 temp_dict = new_yaml_dict[test_name]
+
+                if 'weight_class' not in temp_dict:
+                    if self.default_weight_ != "":
+                        temp_dict['weight_class'] = self.default_weight_
+                    else:
+                        temp_dict['weight_class'] = None
 
                 if not isinstance(temp_dict, dict):
                     print(f"\033[31mWARNING: Error test \"{test_name}\" is not a dict\033[0m")

--- a/TFCTestSystem.py
+++ b/TFCTestSystem.py
@@ -166,6 +166,7 @@ class TFCTestSystem(TFCObject, TFCTraceabilityMatrix, TFCTestResultsDatabase):
         print("Project-root", self.project_root_)
 
         # Process the config file
+        self.num_init_warnings_ = 0
         config_file_path = ""
         possible_config_file_path1 = self.project_root_ + self.config_file_
         possible_config_file_path2 = file_path + "../" + self.config_file_
@@ -265,8 +266,6 @@ class TFCTestSystem(TFCObject, TFCTraceabilityMatrix, TFCTestResultsDatabase):
         self.max_num_procs_ = 1
 
         self.tests_: list[TFCTestObject] = []
-
-        self.num_init_warnings_ = 0
 
         directories = []
         if self.directory_.find(",") < 0:
@@ -501,7 +500,7 @@ class TFCTestSystem(TFCObject, TFCTraceabilityMatrix, TFCTestResultsDatabase):
         active_tests: list[TFCTestObject] = []
 
         # ======================================= Testing phase
-        print("\nRunning tests " + self.weight_classes_allowed_.__str__() + "")
+        print("\nRunning tests with weight class:" + self.weight_classes_allowed_.__str__() + "")
         k = 0
         while True:
             k += 1
@@ -541,7 +540,7 @@ class TFCTestSystem(TFCObject, TFCTraceabilityMatrix, TFCTestResultsDatabase):
         end_time = time.perf_counter()
         elapsed_time = end_time - start_time
 
-        print("Done executing tests with class in: " +
+        print("Done executing tests with weight class: " +
           self.weight_classes_allowed_.__str__())
 
         num_tests_failed = 0

--- a/TFCTestSystem.py
+++ b/TFCTestSystem.py
@@ -56,19 +56,11 @@ class TFCTestSystem(TFCObject, TFCTraceabilityMatrix, TFCTestResultsDatabase):
         params.addOptionalParam("project_root", "",
                                 "Root of the project. If not supplied will revert to " \
                                 "current working directoy.")
-
         params.addOptionalParam("num_jobs", int(4),
                                 "The number of jobs that may run at the same time.")
-        params.addOptionalParam("weights", int(1),
-                                "Weight classes to allow. "
-                                "0=None, "
-                                "1=Short, "
-                                "2=Intermediate, "
-                                "3=Short+Intermediate, "
-                                "4=Long, "
-                                "5=Long+Short, "
-                                "6=Long+Intermediate, "
-                                "7=All")
+        params.addOptionalParam("weights", ["all"],
+                                "Weight classes to execute. "
+                                "Defaults to all.")
         params.addOptionalParam("config_file", "TestSystemCONFIG.yaml",
                                 "The name of the default config file")
         params.addOptionalParam("exclude_folders", [],
@@ -92,7 +84,12 @@ class TFCTestSystem(TFCObject, TFCTraceabilityMatrix, TFCTestResultsDatabase):
         self.directory_ = params.getParam("directory").getStringValue()
         self.executable_ = params.getParam("executable").getStringValue() # AFCF
         self.num_jobs_ = params.getParam("num_jobs").getIntegerValue()
-        self.weights_ = params.getParam("weights").getIntegerValue()
+
+        weights = params.getParam("weights")
+        self.weights_ = []
+        for subparam in weights:
+            self.weights_.append(subparam.getStringValue())
+
         self.config_file_ = params.getParam("config_file").getStringValue()
         self.compiler_ = os.getenv("COMPILER")
         self.os_version_ = platform.version()
@@ -139,31 +136,69 @@ class TFCTestSystem(TFCObject, TFCTraceabilityMatrix, TFCTestResultsDatabase):
         self.test_results_database_outputfile_ = \
             params.getParam("test_results_database_outputfile").getStringValue()
 
-        # Config file options
-        self.print_width_ = 120
-        self.default_args_ = ""
-        self.env_vars_ = []
-
         project_root = params.getParam("project_root").getStringValue()
         if project_root == "":
             self.project_root_ = os.getcwd() + "/" if project_root == "" else project_root
 
         print("Project-root", self.project_root_)
 
-        # Init weight map
-        weight_class_map = ["long", "intermediate", "short"]
-        weight_classes_allowed = []
-        if 0 <= self.weights_ <= 7:
-            binary_weights = '{0:03b}'.format(self.weights_)
-            for k in range(0, 3):
-                if binary_weights[k] == '1':
-                    weight_classes_allowed.append(weight_class_map[k])
-        else:
-            raise RuntimeError(
-                '\033[31mIllegal value "' + str(self.weights_) + '" supplied ' +
-                'for argument -w, --weights\033[0m')
+        # Process the config file
+        config_file_path = ""
+        possible_config_file_path1 = self.project_root_ + self.config_file_
+        possible_config_file_path2 = file_path + "../" + self.config_file_
 
-        self.weight_classes_allowed_ = weight_classes_allowed
+        if os.path.isfile(possible_config_file_path1):
+            config_file_path = possible_config_file_path1
+        elif os.path.isfile(possible_config_file_path2):
+            config_file_path = possible_config_file_path2
+        else:
+            print(f'\033[31mWARNING: No config file {self.config_file_} ' +
+                  f' found at either {possible_config_file_path1} or '
+                  f' {possible_config_file_path2}\033[0m')
+            self.num_init_warnings_ += 1
+
+        # Config file options
+        self.print_width_ = 120
+        self.default_args_ = ""
+        self.env_vars_ = []
+        self.default_weight_ = "short"
+        self.weight_map_ = ""
+
+        with open(config_file_path) as yaml_file:
+            yaml_dict = yaml.safe_load(yaml_file)
+
+            for param in yaml_dict:
+                if param == "default_executable":
+                    self.executable_ = yaml_dict[param]
+                if param == "print_width":
+                    self.print_width_ = yaml_dict[param]
+                if param == "default_args":
+                    self.default_args_ = yaml_dict[param]
+                if param == "env_vars":
+                    self.env_vars_ = yaml_dict[param]
+                if param == "weight_map":
+                    self.weight_map_ = yaml_dict[param]
+                if param == "default_weight":
+                    self.default_weight_ = yaml_dict[param]
+
+        if self.weight_map_ == "":
+            self.weight_map_ = [{"short": 2.0}, {"intermediate": 10.0}, {"long": 20.0}]
+            self.default_weight_ = "short"
+        else:
+            found_weight = False
+            for weight_name in self.weight_map_:
+                for weight in weight_name.keys():
+                    if self.default_weight_ == weight:
+                        found_weight = True
+                        break
+            if found_weight == False:
+                print(f'\033[31mWARNING: default_weight set in config file {self.config_file_} ' +
+                      f'but not found in default weight_map. Falling back to default_weight = "short"\033[0m')
+                self.weight_map_ = [{"short": 2.0}, {"intermediate": 10.0}, {"long": 20.0}]
+                self.default_weight_ = "short"
+
+        self.weight_classes_allowed_ = self.weights_
+
         self.max_num_procs_ = 1
 
         self.tests_: list[TFCTestObject] = []
@@ -186,34 +221,6 @@ class TFCTestSystem(TFCObject, TFCTraceabilityMatrix, TFCTestResultsDatabase):
         for test in self.tests_:
             self.max_num_procs_ = max(self.max_num_procs_, test.num_procs_)
 
-        # Process the config file
-        config_file_path = ""
-        possible_config_file_path1 = self.project_root_ + self.config_file_
-        possible_config_file_path2 = file_path + "../" + self.config_file_
-
-        if os.path.isfile(possible_config_file_path1):
-            config_file_path = possible_config_file_path1
-        elif os.path.isfile(possible_config_file_path2):
-            config_file_path = possible_config_file_path2
-        else:
-            print(f'\033[31mWARNING: No config file {self.config_file_} ' +
-                  f' found at either {possible_config_file_path1} or '
-                  f' {possible_config_file_path2}\033[0m')
-            self.num_init_warnings_ += 1
-
-        with open(config_file_path) as yaml_file:
-            yaml_dict = yaml.safe_load(yaml_file)
-
-            for param in yaml_dict:
-                if param == "default_executable":
-                    self.executable_ = yaml_dict[param]
-                if param == "print_width":
-                    self.print_width_ = yaml_dict[param]
-                if param == "default_args":
-                    self.default_args_ = yaml_dict[param]
-                if param == "env_vars":
-                    self.env_vars_ = yaml_dict[param]
-
         # Clean up executable
         exe_printed_value = self.executable_.strip()
         if exe_printed_value.find("$") == 0:
@@ -229,6 +236,7 @@ class TFCTestSystem(TFCObject, TFCTraceabilityMatrix, TFCTestResultsDatabase):
         print(f" Main executable        : {exe_printed_value}")
         print(f" Number of jobs         : {self.num_jobs_}")
         print(f" Weight classes         : {self.weight_classes_allowed_}")
+        print(f" Default weight class   : {self.default_weight_}")
         print(f" Compiler env-var       : {self.compiler_}")
         print(f" System details         : {self.os_details_}")
         print(f" System version         : {self.os_version_}")
@@ -337,7 +345,8 @@ class TFCTestSystem(TFCObject, TFCTraceabilityMatrix, TFCTestResultsDatabase):
 
                     # check if weight class is allowed
                     if 'weight_class' not in temp_dict:
-                        if 'short' not in self.weight_classes_allowed_:
+                        temp_dict['weight_class'] = self.default_weight_
+                        if self.default_weight_ not in self.weight_classes_allowed_:
                             continue
                     else:
                         if temp_dict['weight_class'] not in self.weight_classes_allowed_:
@@ -449,24 +458,6 @@ class TFCTestSystem(TFCObject, TFCTraceabilityMatrix, TFCTestResultsDatabase):
             for test in active_tests:
                 try:
                     if test.checkProgress(self) == "Running":
-
-                        # Check if the test has run beyond permitted time.
-                        # This prevents hanging tests that never finish.
-                        if test.weight_class_ == "short":
-                            if test._time_current_ >= 300.0: # 5 minutes
-                                test.skip_ = "Short test ran longer than 5 minutes."
-                                # test._process_.terminate()
-                        elif test.weight_class_ == "medium":
-                            if test._time_current_ >= 600.0: # 10 minutes
-                                test.skip_ = "Medium test ran longer than 10 minutes."
-                                test._process_.terminate()
-                        elif test.weight_class_ == "long":
-                            if test._time_current_ >= 1800.0: # 30 minutes
-                                test.skip_ = "Long test ran longer than 30 minutes."
-                                test._process_.terminate()
-                        else:
-                            pass
-
                         system_load += test.num_procs_
                 except Exception as ex:
                     print(f"\033[31mERROR: Test {test.name_}"

--- a/TFCTestSystem.py
+++ b/TFCTestSystem.py
@@ -453,14 +453,17 @@ class TFCTestSystem(TFCObject, TFCTraceabilityMatrix, TFCTestResultsDatabase):
                         # Check if the test has run beyond permitted time.
                         # This prevents hanging tests that never finish.
                         if test.weight_class_ == "short":
-                            if test._time_current_ >= 60.0: # 1 minute
-                                test.skip_ = "Short test ran longer than 1 minute."
+                            if test._time_current_ >= 300.0: # 5 minutes
+                                test.skip_ = "Short test ran longer than 5 minutes."
+                                # test._process_.terminate()
                         elif test.weight_class_ == "medium":
                             if test._time_current_ >= 600.0: # 10 minutes
                                 test.skip_ = "Medium test ran longer than 10 minutes."
+                                test._process_.terminate()
                         elif test.weight_class_ == "long":
                             if test._time_current_ >= 1800.0: # 30 minutes
                                 test.skip_ = "Long test ran longer than 30 minutes."
+                                test._process_.terminate()
                         else:
                             pass
 

--- a/TFCTestSystem.py
+++ b/TFCTestSystem.py
@@ -96,6 +96,10 @@ class TFCTestSystem(TFCObject, TFCTraceabilityMatrix, TFCTestResultsDatabase):
 
         self.no_time_limit_ = params.getParam("no_time_limit").getBooleanValue()
 
+        # This is an absolute value that gets populated with a non-zero value by the performance unit test.
+        # Case specific performance tests are benchmarked against a ratio relative to this.
+        self.execution_time_ = 0.0
+
         self.config_file_ = params.getParam("config_file").getStringValue()
         self.compiler_ = os.getenv("COMPILER")
         self.os_version_ = platform.version()

--- a/TFCTestSystem.py
+++ b/TFCTestSystem.py
@@ -482,7 +482,8 @@ class TFCTestSystem(TFCObject, TFCTraceabilityMatrix, TFCTestResultsDatabase):
             if not test.passed_:
                 num_tests_failed += 1
             if test.skip_:
-                num_tests_skipped += 1
+                if not test.passed_:
+                    num_tests_skipped += 1
 
         print()
         print("Elapsed time                       : {:.2f} seconds".format(elapsed_time))

--- a/TFCTestSystem.py
+++ b/TFCTestSystem.py
@@ -60,8 +60,13 @@ class TFCTestSystem(TFCObject, TFCTraceabilityMatrix, TFCTestResultsDatabase):
         params.addOptionalParam("num_jobs", int(4),
                                 "The number of jobs that may run at the same time.")
         params.addOptionalParam("weights", ["all"],
-                                "Weight classes to execute. "
-                                "Defaults to all.")
+                                'Weight classes to execute. '
+                                'Defaults to ["all"]. The classes allowed '
+                                'depends on whether a custom weight map has '
+                                'been assigned in the test system config file. '
+                                'If no custom weight map is assigned then the '
+                                'weight classes will be short, intermediate, or '
+                                'long, or all.')
         params.addOptionalParam("no_time_limit", False,
                                 "Don't enforce weight class time limits. "
                                 "Defaults to False.")
@@ -196,23 +201,50 @@ class TFCTestSystem(TFCObject, TFCTraceabilityMatrix, TFCTestResultsDatabase):
                 if param == "default_weight":
                     self.default_weight_ = yaml_dict[param]
 
+                if param == "requirement_docs":
+                    requirement_docs = yaml_dict[param]
+                    self.requirement_docs_ = []
+                    for subparam in requirement_docs:
+                        self.requirement_docs_.append(subparam)
+
+                    if len(self.requirement_docs_) > 0:
+                        print("Requirement docs:")
+                        for req_doc in self.requirement_docs_:
+                            existence_status = "" if os.path.isfile(req_doc) else " (not found)"
+                            print(f"  {req_doc}" + existence_status)
+
+                    self.requirement_blocks_ = []
+                    for req_doc in self.requirement_docs_:
+                        if not os.path.isfile(req_doc):
+                            continue
+
+                        doc_reqs = self.parseRequirementDocument(req_doc)
+
+                        self.requirement_blocks_.append(doc_reqs)
+
+                if param == "requirements_output":
+                    self.requirements_matrix_outputfile_ = yaml_dict[param]
+                if param == "results_output":
+                    self.test_results_database_outputfile_= yaml_dict[param]
+
         if self.weight_map_ == "":
-            self.weight_map_ = [{"short": 2.0}, {"intermediate": 10.0}, {"long": 20.0}]
+            self.weight_map_ = {"short": 2.0, "intermediate": 10.0, "long": 20.0}
 
         if self.default_weight_ != "":
-            found_weight = False
-            for weight_name in self.weight_map_:
-                for weight in weight_name.keys():
-                    if self.default_weight_ == weight:
-                        found_weight = True
-                        break
-            if found_weight == False:
+            if self.default_weight_ not in self.weight_map_:
                 print(f'\033[31mWARNING: default_weight set in config file {self.config_file_} ' +
                       f'but not found in weight_map. Ignoring default_weight.\033[0m')
                 self.default_weight_ = ""
 
         if "all" in self.weights_:
-            self.weights_ = [weight for weight_map in self.weight_map_ for weight in weight_map.keys()]
+            self.weights_ = list(self.weight_map_.keys())
+
+        # check if we have unrecognized weights
+        for weight in self.weights_:
+            if weight not in self.weight_map_:
+                print(f'\033[31mWARNING: weight "{weight}" is not in weight_map. '
+                      f'Falling back to "all".\033[0m')
+                self.weights_ = list(self.weight_map_.keys())
 
         self.weight_classes_allowed_ = self.weights_
 
@@ -256,15 +288,15 @@ class TFCTestSystem(TFCObject, TFCTraceabilityMatrix, TFCTestResultsDatabase):
 
         print("\n***** TFCTestSystem created *****")
 
-        print(f" Main executable        : {exe_printed_value}")
-        print(f" Number of jobs         : {self.num_jobs_}")
-        print(f" Weight classes         : {self.weight_classes_allowed_}")
-        if self.default_weight_ != "":
-            print(f" Default weight class   : {self.default_weight_}")
-        print(f" Compiler env-var       : {self.compiler_}")
-        print(f" System details         : {self.os_details_}")
-        print(f" System version         : {self.os_version_}")
-        print(f" System release         : {self.os_release_}")
+        print(f" Main executable          : {exe_printed_value}")
+        print(f" Number of jobs           : {self.num_jobs_}")
+        print(f" Weight map               : {self.weight_classes_allowed_}")
+        print(f" Weight class time limits : {self.weight_map_}")
+        print(f" Default weight class     : {self.default_weight_}")
+        print(f" Compiler env-var         : {self.compiler_}")
+        print(f" System details           : {self.os_details_}")
+        print(f" System version           : {self.os_version_}")
+        print(f" System release           : {self.os_release_}")
         print(f" ")
 
 
@@ -510,8 +542,7 @@ class TFCTestSystem(TFCObject, TFCTraceabilityMatrix, TFCTestResultsDatabase):
             if not test.passed_:
                 num_tests_failed += 1
             if test.skip_:
-                if not test.passed_:
-                    num_tests_skipped += 1
+                num_tests_skipped += 1
 
         print()
         print("Elapsed time                       : {:.2f} seconds".format(elapsed_time))

--- a/TFCTestSystem.py
+++ b/TFCTestSystem.py
@@ -449,6 +449,21 @@ class TFCTestSystem(TFCObject, TFCTraceabilityMatrix, TFCTestResultsDatabase):
             for test in active_tests:
                 try:
                     if test.checkProgress(self) == "Running":
+
+                        # Check if the test has run beyond permitted time.
+                        # This prevents hanging tests that never finish.
+                        if test.weight_class_ == "short":
+                            if test._time_current_ >= 60.0: # 1 minute
+                                test.skip_ = "Short test ran longer than 1 minute."
+                        elif test.weight_class_ == "medium":
+                            if test._time_current_ >= 600.0: # 10 minutes
+                                test.skip_ = "Medium test ran longer than 10 minutes."
+                        elif test.weight_class_ == "long":
+                            if test._time_current_ >= 1800.0: # 30 minutes
+                                test.skip_ = "Long test ran longer than 30 minutes."
+                        else:
+                            pass
+
                         system_load += test.num_procs_
                 except Exception as ex:
                     print(f"\033[31mERROR: Test {test.name_}"

--- a/TFCTestSystem.py
+++ b/TFCTestSystem.py
@@ -14,6 +14,7 @@ from TFCTestObject import *
 from TFCTraceabilityMatrix import *
 from TFCTestResultsDatabase import *
 
+import shutil
 import os
 import yaml
 import re
@@ -61,6 +62,9 @@ class TFCTestSystem(TFCObject, TFCTraceabilityMatrix, TFCTestResultsDatabase):
         params.addOptionalParam("weights", ["all"],
                                 "Weight classes to execute. "
                                 "Defaults to all.")
+        params.addOptionalParam("no_time_limit", False,
+                                "Don't enforce weight class time limits. "
+                                "Defaults to False.")
         params.addOptionalParam("config_file", "TestSystemCONFIG.yaml",
                                 "The name of the default config file")
         params.addOptionalParam("exclude_folders", [],
@@ -89,6 +93,8 @@ class TFCTestSystem(TFCObject, TFCTraceabilityMatrix, TFCTestResultsDatabase):
         self.weights_ = []
         for subparam in weights:
             self.weights_.append(subparam.getStringValue())
+
+        self.no_time_limit_ = params.getParam("no_time_limit").getBooleanValue()
 
         self.config_file_ = params.getParam("config_file").getStringValue()
         self.compiler_ = os.getenv("COMPILER")
@@ -158,7 +164,12 @@ class TFCTestSystem(TFCObject, TFCTraceabilityMatrix, TFCTestResultsDatabase):
             self.num_init_warnings_ += 1
 
         # Config file options
-        self.print_width_ = 120
+        try:
+            size = shutil.get_terminal_size()
+            width = size.columns
+            self.print_width_ = width - 10
+        except:
+            self.print_width_ = 120
         self.default_args_ = ""
         self.env_vars_ = []
         self.default_weight_ = ""
@@ -201,11 +212,11 @@ class TFCTestSystem(TFCObject, TFCTraceabilityMatrix, TFCTestResultsDatabase):
 
         self.weight_classes_allowed_ = self.weights_
 
-        # Append "None" weight class to weight_classes_allowed
+        # Append "none" weight class to weight_classes_allowed
         # This makes the test system agnostic to the weight class definitions
         # and allows tests to run that have no assignment without explicity
         # assigning them to an arbitrary member of the weight classes
-        self.weight_classes_allowed_.append(None)
+        self.weight_classes_allowed_.append("none")
 
         self.max_num_procs_ = 1
 
@@ -379,7 +390,7 @@ class TFCTestSystem(TFCObject, TFCTraceabilityMatrix, TFCTestResultsDatabase):
                     if self.default_weight_ != "":
                         temp_dict['weight_class'] = self.default_weight_
                     else:
-                        temp_dict['weight_class'] = None
+                        temp_dict['weight_class'] = "none"
 
                 if not isinstance(temp_dict, dict):
                     print(f"\033[31mWARNING: Error test \"{test_name}\" is not a dict\033[0m")

--- a/doc/A02_ConfigFile.md
+++ b/doc/A02_ConfigFile.md
@@ -4,16 +4,32 @@ With this file, any of the test system input parameters can be overridden since
 it is processed after command line arguments are assigned. Additionally, it
 supports several other input options:
   - `print_width`, The maximum width of the test system message printing. This
-  can be used to prevent line-wrapping when running the tests.
+    can be used to prevent line-wrapping when running the tests.
   - `default_args`, A set of arguments to be prepended to all tests' arguments.
   - `env_vars`, A list of strings representing the environment variables that
     are registered within the test system. These variables can be used as
     substitutions within test arguments, or pre/post-scripts.
+  - `weight_map`, A dictionary of weight keys and corresponding weight time
+    limit values in seconds.
+  - `weights`, A list of strings that correspond to the weight classes that
+   should be executed by the test system.
+  - `default_weight`, The weight class that is assigned to uncategorized tests.
+  - `requirement_docs`, A list of strings that correspond to the paths to
+   test requirements matrix documentation.
+  - `requirements_output`, A string path to the test requirements output
+    traceability matrix file.
 
 Example config file:
 ```
 default_executable: $RELAP_EXE
 print_width: 97
 num_jobs: 48
-weights: 7
+weights: ["short"]
+weight_map:
+  "short": 5.0
+  "intermediate": 30.0
+  "long": 60.0
+default_weight: "short"
+requirement_docs: [path/to/my/requirements.md]
+requirements_output: path/to/my/traceability_matrix.md
 ```


### PR DESCRIPTION
1. Added a check for short, medium and long tests to see if they are taking longer than a set limit. Currently short is 60 seconds, medium is 10 minutes, and long is 30 minutes.
2. Tests check if their dependency was skipped for the above reason.
3. Many tests in 'short' are being skipped, solution is either to change them to higher weight class or increase the time allowed.